### PR TITLE
Add total coverage to report

### DIFF
--- a/cmd/go-coverage-report/main.go
+++ b/cmd/go-coverage-report/main.go
@@ -104,7 +104,6 @@ func run(oldCovPath, newCovPath, changedFilesPath string, opts options) error {
 	switch strings.ToLower(opts.format) {
 	case "markdown":
 		fmt.Fprintln(os.Stdout, report.Markdown())
-		fmt.Fprintf(os.Stdout, "\nTotal Coverage: %.2f%%\n", newCov.Percent())
 	case "json":
 		fmt.Fprintln(os.Stdout, report.JSON())
 	default:

--- a/cmd/go-coverage-report/main.go
+++ b/cmd/go-coverage-report/main.go
@@ -104,6 +104,7 @@ func run(oldCovPath, newCovPath, changedFilesPath string, opts options) error {
 	switch strings.ToLower(opts.format) {
 	case "markdown":
 		fmt.Fprintln(os.Stdout, report.Markdown())
+		fmt.Fprintf(os.Stdout, "\nTotal Coverage: %.2f%%\n", newCov.Percent())
 	case "json":
 		fmt.Fprintln(os.Stdout, report.JSON())
 	default:

--- a/cmd/go-coverage-report/report.go
+++ b/cmd/go-coverage-report/report.go
@@ -89,7 +89,7 @@ func (r *Report) Markdown() string {
 	fmt.Fprintln(report, "|-------------------|------------|---------|")
 
 	oldCovPkgs := r.Old.ByPackage()
-	newCovPkPkgs := r.New.ByPackage()
+	newCovPkgs := r.New.ByPackage()
 	for _, pkg := range r.ChangedPackages {
 		var oldPercent, newPercent float64
 

--- a/cmd/go-coverage-report/report.go
+++ b/cmd/go-coverage-report/report.go
@@ -89,7 +89,7 @@ func (r *Report) Markdown() string {
 	fmt.Fprintln(report, "|-------------------|------------|---------|")
 
 	oldCovPkgs := r.Old.ByPackage()
-	newCovPkgs := r.New.ByPackage()
+	newCovPkPkgs := r.New.ByPackage()
 	for _, pkg := range r.ChangedPackages {
 		var oldPercent, newPercent float64
 
@@ -109,6 +109,8 @@ func (r *Report) Markdown() string {
 			emoji,
 		)
 	}
+
+	fmt.Fprintln(report, "| **Total** | **%.2f%%** | |\n", r.New.Percent())
 
 	report.WriteString("\n")
 	r.addDetails(report)

--- a/cmd/go-coverage-report/report.go
+++ b/cmd/go-coverage-report/report.go
@@ -110,7 +110,7 @@ func (r *Report) Markdown() string {
 		)
 	}
 
-	fmt.Fprintln(report, "| **Total** | **%.2f%%** | |\n", r.New.Percent())
+	fmt.Fprintf(report, "| **Total** | **%.2f%%** | |\n", r.New.Percent())
 
 	report.WriteString("\n")
 	r.addDetails(report)

--- a/cmd/go-coverage-report/report_test.go
+++ b/cmd/go-coverage-report/report_test.go
@@ -27,6 +27,8 @@ func TestReport_Markdown(t *testing.T) {
 | github.com/fgrosse/prioqueue | 90.20% (**-9.80%**) | :thumbsdown: |
 | github.com/fgrosse/prioqueue/foo/bar | 0.00% (ø) |  |
 
+| **Total** | **90.20%** | |
+
 ---
 
 <details>
@@ -64,6 +66,8 @@ func TestReport_Markdown_OnlyChangedUnitTests(t *testing.T) {
 | Impacted Packages | Coverage Δ | :robot: |
 |-------------------|------------|---------|
 | github.com/fgrosse/prioqueue | 99.02% (**+8.82%**) | :thumbsup: |
+
+| **Total** | **99.02%** | |
 
 ---
 

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -149,3 +149,8 @@ fi
 
 gh pr comment "$GITHUB_PULL_REQUEST_NUMBER" --body-file=$COVERAGE_COMMENT_PATH
 end_group
+
+start_group "Output total coverage"
+TOTAL_COVERAGE=$(go-coverage-report -root="$ROOT_PACKAGE" -trim="$TRIM_PACKAGE" "$OLD_COVERAGE_PATH" "$NEW_COVERAGE_PATH" "$CHANGED_FILES_PATH" | grep "Total Coverage" | awk '{print $3}')
+echo "Total Coverage: $TOTAL_COVERAGE"
+end_group

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -149,4 +149,3 @@ fi
 
 gh pr comment "$GITHUB_PULL_REQUEST_NUMBER" --body-file=$COVERAGE_COMMENT_PATH
 end_group
-

--- a/scripts/github-action.sh
+++ b/scripts/github-action.sh
@@ -150,7 +150,3 @@ fi
 gh pr comment "$GITHUB_PULL_REQUEST_NUMBER" --body-file=$COVERAGE_COMMENT_PATH
 end_group
 
-start_group "Output total coverage"
-TOTAL_COVERAGE=$(go-coverage-report -root="$ROOT_PACKAGE" -trim="$TRIM_PACKAGE" "$OLD_COVERAGE_PATH" "$NEW_COVERAGE_PATH" "$CHANGED_FILES_PATH" | grep "Total Coverage" | awk '{print $3}')
-echo "Total Coverage: $TOTAL_COVERAGE"
-end_group


### PR DESCRIPTION
Add total coverage to the generated report and output.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/teamniteo/go-coverage-report/pull/1?shareId=c17ffae2-532c-4fe4-a162-154659bc1dd9).